### PR TITLE
use replaceQueryParam instead of queryParam

### DIFF
--- a/java/src/com/tableausoftware/documentation/api/rest/util/RestApiUtils.java
+++ b/java/src/com/tableausoftware/documentation/api/rest/util/RestApiUtils.java
@@ -678,8 +678,8 @@ public class RestApiUtils {
 
         // Builds the URL with the upload session id and workbook type
         UriBuilder builder = Operation.PUBLISH_WORKBOOK.getUriBuilder()
-                .queryParam("uploadSessionId", fileUpload.getUploadSessionId())
-                .queryParam("workbookType", Files.getFileExtension(workbookFile.getName()));
+                .replaceQueryParam("uploadSessionId", fileUpload.getUploadSessionId())
+                .replaceQueryParam("workbookType", Files.getFileExtension(workbookFile.getName()));
         String url = builder.build(siteId, fileUpload.getUploadSessionId()).toString();
 
         // Creates a buffer to read 100KB at a time


### PR DESCRIPTION
I think use `replaceQueryParam` is more better, because when I call the same url one more time, the real url has several `workbookType` param , suche as` ***?workbookType=1&workbookType=2`, it make the result out of control