### PR TITLE
Update log4j and jaxb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+/java/build/*
+/java/.idea/*
+/java/lib/*

--- a/java/README.md
+++ b/java/README.md
@@ -1,7 +1,7 @@
 
 ## Requirements
 
-* Tableau Server
+* Tableau Server, or an account on Tableau Cloud
 * Java SDK
   * Download: <http://www.oracle.com/technetwork/java/javase/downloads/index.html>
 * Apache Ant
@@ -14,39 +14,14 @@
 ## Getting started
 
 1. Install the tools listed in the "Requirements" section.
-1. Download the REST API schema and save it in the `/res` folder under the folder where this README file is. For more information about the schema, see the following documentation:
-
-   <http://onlinehelp.tableau.com/current/api/rest_api/en-us/help.htm#REST/rest_api_concepts_schema.htm>
-
-1. In the `/res` folder, open the `config.properties` file using a text editor.
-1. Modify the configurations as instructed in the file. A sample workbook is already provided with this sample, but you can use any packaged workbook that you want.
-1. Open the following file in a text editor:
-
-   ```
-   src\com\tableausoftware\documentation\api\rest\util\RestApiUtils.java
-   ```
-
-1. Find the `getApiUriBuilder()` method, and replace the API URL with the correct version number.
-
-   For example, you might see the following URL:
-
-   ```
-   /api/3.1/
-   ```
-
-   If you want to use version 3.0 of the API, replace the URL with the following:
-
-   ```
-   /api/3.0/
-   ```
-
-## Running the sample
-
-1. Make sure that Tableau Server is running.
+   1. Make sure that Tableau Server is running if you are using your own server.
+1. In the /res folder, open the config.properties file using a text editor.
+   1. Modify the configurations as instructed in the file. 
+   2. A sample workbook is already provided with this sample, but you can use any packaged workbook that you want.
 1. Open a command prompt or terminal.
-1. In the command prompt window, change directory to the sample code's parent folder.
-1. Enter `ant` in the command prompt to compile the sample code and download dependencies.
-1. Enter `ant run` in the command prompt to run the sample code after compilation.
+   1. In the command prompt window, change directory to the sample code's parent folder.
+   1. Enter `ant` in the command prompt to compile the sample code and download dependencies.
+   1. Enter `ant run` in the command prompt to run the sample code after compilation.
 
 ## Possible problems
 
@@ -54,3 +29,13 @@ When `ant` is run in a command prompt, it may respond with "ant is not recognize
 
 Make sure that the `ANT_HOME` and `JAVA_HOME` variables are set as described in the installation guide for Apache Ant. Paths should not include quotes.
 For more information, see <http://ant.apache.org/manual/install.html#windows>
+------
+
+The example code uses version 3.0 of the REST API and schema. If you want to use a different version:
+1. Download the REST API schema and save it in the `/res` folder under the folder where this README file is. For more information about the schema, see the following documentation:
+
+   <http://onlinehelp.tableau.com/current/api/rest_api/en-us/help.htm#REST/rest_api_concepts_schema.htm>
+
+1. In the `/res` folder, open the `config.properties` file using a text editor.
+1. Update the schema configuration properties to match the new file.
+------

--- a/java/build.xml
+++ b/java/build.xml
@@ -1,18 +1,11 @@
 <!--
  Ant build file for the project jar.
-
- All functionality comes from the common-module.xml Ant script.
- Do not add targets or properties here unless they are
- only specific to this module.
-
- Note that including the local ant.properties file must
- happen before importing the common-module.xml to ensure
- properties are overridden correctly.
-
- Type "ant -p" to see the list of available targets.
 -->
 <project name="tab-documentation-api" basedir="." default="main" xmlns:ivy="antlib:org.apache.ivy.ant">
     <property file="ant.properties"/>
+    <presetdef name="javac">
+        <javac includeantruntime="false" />
+    </presetdef>
 
     <path id="classpath">
         <fileset dir="${lib.dir}" includes="**/*.jar"/>

--- a/java/ivy.xml
+++ b/java/ivy.xml
@@ -4,7 +4,8 @@
         <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
         <dependency org="com.google.guava" name="guava" rev="16.0.1"/>
         <!-- https://mvnrepository.com/artifact/log4j/log4j -->
-        <dependency org="log4j" name="log4j" rev="1.2.17"/>
+        <dependency org="org.apache.logging.log4j" name="log4j-api" rev="2.19.0" />
+        <dependency org="org.apache.logging.log4j" name="log4j-core" rev="2.19.0" />
         <!-- https://mvnrepository.com/artifact/com.sun.jersey/jersey-client -->
         <dependency org="com.sun.jersey" name="jersey-client" rev="1.18.3"/>
         <!-- https://mvnrepository.com/artifact/com.sun.jersey/jersey-core -->
@@ -12,7 +13,10 @@
         <!-- https://mvnrepository.com/artifact/com.sun.jersey.contribs/jersey-multipart -->
         <dependency org="com.sun.jersey.contribs" name="jersey-multipart" rev="1.18.3"/>
         <!-- https://mvnrepository.com/artifact/com.sun.jersey/jersey-server -->
-        <!-- https://mvnrepository.com/artifact/com.sun.jersey/jersey-server -->
         <dependency org="com.sun.jersey" name="jersey-server" rev="1.18.3"/>
+        <!-- JAXB API only -->
+        <dependency org="jakarta.xml.bind" name="jakarta.xml.bind-api" rev="2.3.3"/>
+        <!-- JAXB RI, Jakarta XML Binding -->
+        <dependency org="com.sun.xml.bind" name="jaxb-ri" rev="2.3.3" />
     </dependencies>
 </ivy-module>

--- a/java/res/config.properties
+++ b/java/res/config.properties
@@ -1,10 +1,11 @@
 # Set this to the name or IP address of the Tableau Server installation.
 server.host=http://YOUR-SERVER
 
-# Set where the REST API schema is located
+# Set where the REST API schema is located and the version to use
 # The latest schema can be downloaded from here:
 # http://onlinehelp.tableau.com/current/api/rest_api/en-us/help.htm#REST/rest_api_concepts_schema.htm
-server.schema.location=res/ts-api_X_X.xsd
+server.schema.location=res/ts-api_3_0.xsd
+server.schema.version=3.0
 
 # Set this to the content URL of the default site.
 # Not assigning a value to this configuration references the default site.

--- a/java/res/ts-api_3_0.xsd
+++ b/java/res/ts-api_3_0.xsd
@@ -1,0 +1,834 @@
+<xs:schema xmlns="http://tableau.com/api" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://tableau.com/api" elementFormDefault="qualified">
+
+
+    <!--
+        Definition of request and response elements that wrap all payloads.
+        Definition of the error message payload.
+    -->
+
+    <xs:element name="tsRequest">
+        <xs:complexType>
+            <xs:choice>
+                <xs:element name="connection" type="connectionType" />
+                <xs:element name="connections" type="connectionListType" />
+                <xs:element name="credentials" type="tableauCredentialsType" />
+                <xs:element name="datasource" type="dataSourceType" />
+                <xs:element name="favorite" type="favoriteType" />
+                <xs:element name="group" type="groupType" />
+                <xs:element name="permissions" type="permissionsType" />
+                <xs:element name="project" type="projectType" />
+                <xs:element name="schedule" type="scheduleType" />
+                <xs:element name="site" type="siteType" />
+                <xs:element name="tags" type="tagListType" />
+                <xs:element name="user" type="userType" />
+                <xs:element name="workbook" type="workbookType" />
+                <xs:element name="subscription" type="subscriptionType" />
+                <xs:element name="task" type="taskType" />
+            </xs:choice>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="tsResponse">
+        <xs:complexType>
+            <xs:choice>
+                <xs:group ref="paginatedResponseGroup" />
+                <xs:element name="connection" type="connectionType" />
+                <xs:element name="connections" type="connectionListType" />
+                <xs:element name="credentials" type="tableauCredentialsType" />
+                <xs:element name="datasource" type="dataSourceType" />
+                <xs:element name="error" type="errorType" />
+                <xs:element name="favorites" type="favoriteListType" />
+                <xs:element name="fileUpload" type="fileUploadType" />
+                <xs:element name="group" type="groupType" />
+                <xs:element name="job" type="jobType" />
+                <xs:element name="permissions" type="permissionsType" />
+                <xs:element name="project" type="projectType" />
+                <xs:element name="schedule" type="scheduleType" />
+                <xs:element name="serverInfo" type="serverInfo" />
+                <xs:element name="site" type="siteType" />
+                <xs:element name="tags" type="tagListType" />
+                <xs:element name="user" type="userType" />
+                <xs:element name="views" type="viewListType" />
+                <xs:element name="workbook" type="workbookType" />
+                <xs:element name="subscription" type="subscriptionType" />
+                <xs:element name="task" type="taskType" />
+                <xs:element name="tasks" type="taskListType" />
+            </xs:choice>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:group name="paginatedResponseGroup">
+        <xs:sequence>
+            <xs:element name="pagination" type="paginationType" />
+            <xs:choice>
+                <xs:element name="datasources" type="dataSourceListType" />
+                <xs:element name="extracts" type="extractListType" />
+                <xs:element name="groups" type="groupListType" />
+                <xs:element name="projects" type="projectListType" />
+                <xs:element name="revisions" type="revisionListType" />
+                <xs:element name="schedules" type="scheduleListType" />
+                <xs:element name="sites" type="siteListType" />
+                <xs:element name="users" type="userListType" />
+                <xs:element name="workbooks" type="workbookListType" />
+                <xs:element name="subscriptions" type="subscriptionListType"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:group>
+
+    <xs:complexType name="errorType">
+        <xs:sequence>
+            <xs:element name="summary" type="xs:string" />
+            <xs:element name="detail" type="xs:string" />
+            <xs:element name="callstack" type="xs:string" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" type="xs:positiveInteger" use="required" />
+    </xs:complexType>
+
+
+    <!--
+        Definition of types for the primary entities that are included in the payloads of requests and responses.
+    -->
+
+    <!-- Credentials for a workbook or datasource connection -->
+    <xs:complexType name="connectionCredentialsType">
+        <xs:attribute name="name" type="xs:string" />
+        <xs:attribute name="password" type="xs:string" />
+        <xs:attribute name="embed" type="xs:boolean" />
+        <xs:attribute name="oAuth" type="xs:boolean" />
+    </xs:complexType>
+
+    <xs:complexType name="connectionListType">
+        <xs:sequence>
+            <xs:element name="connection" type="connectionType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="connectionType">
+        <xs:sequence>
+            <xs:element name="datasource" type="dataSourceType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="connectionCredentials" type="connectionCredentialsType" minOccurs="0" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="id" type="resourceIdType" />
+        <xs:attribute name="type" type="xs:string" />
+        <xs:attribute name="serverAddress" type="xs:string" />
+        <xs:attribute name="serverPort" type="xs:nonNegativeInteger" />
+        <xs:attribute name="userName" type="xs:string" />
+        <xs:attribute name="password" type="xs:string" />
+    </xs:complexType>
+
+    <xs:complexType name="dataSourceListType">
+        <xs:sequence>
+            <xs:element name="datasource" type="dataSourceType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="dataSourceType">
+        <xs:sequence>
+            <xs:element name="connectionCredentials" type="connectionCredentialsType" minOccurs="0" />
+            <xs:element name="site" type="siteType" minOccurs="0" />
+            <xs:element name="project" type="projectType" minOccurs="0" />
+            <xs:element name="owner" type="userType" minOccurs="0" />
+            <xs:element name="tags" type="tagListType" minOccurs="0" />
+        </xs:sequence>
+        <xs:attribute name="id" type="resourceIdType" />
+        <xs:attribute name="name" type="xs:string" />
+        <xs:attribute name="contentUrl" type="xs:string" />
+        <xs:attribute name="description" type="xs:string" />
+        <xs:attribute name="type" type="xs:string" />
+        <xs:attribute name="createdAt" type="xs:dateTime" />
+        <xs:attribute name="updatedAt" type="xs:dateTime" />
+        <xs:attribute name="isCertified" type="xs:boolean" />
+        <xs:attribute name="certificationNote" type="xs:string" />
+    </xs:complexType>
+
+    <xs:complexType name="revisionListType">
+        <xs:sequence>
+            <xs:element name="revision" type="revisionType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="revisionType">
+        <xs:sequence>
+            <xs:element name="publisher" type="userType" minOccurs="0" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="revisionNumber" type="xs:nonNegativeInteger" />
+        <xs:attribute name="publishedAt" type="xs:dateTime" />
+        <xs:attribute name="deleted" type="xs:boolean" />
+        <xs:attribute name="current" type="xs:boolean" />
+        <xs:attribute name="sizeInBytes" type="xs:long" />
+    </xs:complexType>
+
+    <xs:complexType name="extractListType">
+        <xs:sequence>
+            <xs:element name="extract" type="extractType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="extractType">
+        <xs:choice>
+            <xs:element name="datasource" type="dataSourceType" />
+            <xs:element name="workbook" type="workbookType" />
+        </xs:choice>
+        <xs:attribute name="id" type="resourceIdType" />
+        <xs:attribute name="priority" type="xs:nonNegativeInteger" />
+        <xs:attribute name="type" >
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="IncrementalRefresh" />
+                    <xs:enumeration value="FullRefresh" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="favoriteListType">
+        <xs:sequence>
+            <xs:element name="favorite" type="favoriteType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="favoriteType">
+        <xs:choice>
+            <xs:element name="view" type="viewType" />
+            <xs:element name="workbook" type="workbookType" />
+            <xs:element name="datasource" type="dataSourceType" />
+        </xs:choice>
+        <xs:attribute name="label" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="fileUploadType">
+        <xs:attribute name="uploadSessionId" type="fileUploadSessionIdType" use="required" />
+        <xs:attribute name="fileSize" type="xs:nonNegativeInteger" />
+    </xs:complexType>
+
+    <xs:complexType name="groupListType">
+        <xs:sequence>
+            <xs:element name="group" type="groupType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="groupType">
+        <xs:sequence>
+            <xs:element name="domain" type="domainDirectiveType" minOccurs="0" />
+            <xs:element name="import" type="importDirectiveType" minOccurs="0" />
+        </xs:sequence>
+        <xs:attribute name="id" type="resourceIdType" />
+        <xs:attribute name="name" type="xs:string" />
+    </xs:complexType>
+
+    <!-- Probably want more in here than just the notes like information about the thing refreshed -->
+    <xs:complexType name="extractRefreshJobType">
+        <xs:sequence>
+            <xs:element name="notes" type="xs:string" />
+            <xs:choice>
+                <xs:element name="view" type="viewType" />
+                <xs:element name="workbook" type="workbookType" />
+                <xs:element name="datasource" type="dataSourceType" />
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="jobType">
+        <!-- This is a sequence right now purely for backwards compat -->
+        <xs:sequence>
+            <xs:element name="statusNotes" type="statusNoteListType" minOccurs="0" />
+            <xs:element name="extractRefreshJob" type="extractRefreshJobType" minOccurs="0" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="id" type="resourceIdType" />
+        <xs:attribute name="mode">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="Asynchronous" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="type">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="GroupSync" />
+                    <xs:enumeration value="RefreshExtract" />
+                    <xs:enumeration value="PublishWorkbook" />
+                    <xs:enumeration value="PublishDatasource" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="progress" type="xs:nonNegativeInteger" />
+        <xs:attribute name="createdAt" type="xs:dateTime" />
+        <xs:attribute name="startedAt" type="xs:dateTime" />
+        <xs:attribute name="updatedAt" type="xs:dateTime" />
+        <xs:attribute name="completedAt" type="xs:dateTime" />
+        <xs:attribute name="finishCode" type="xs:integer" />
+    </xs:complexType>
+
+    <xs:complexType name="permissionsType">
+        <xs:sequence>
+            <xs:element name="parent" type="parentType" minOccurs="0" maxOccurs="1" />
+            <xs:choice minOccurs="0" >
+                <xs:element name="datasource" type="dataSourceType" />
+                <xs:element name="project" type="projectType" />
+                <xs:element name="workbook" type="workbookType" />
+            </xs:choice>
+            <xs:element name="granteeCapabilities" type="granteeCapabilitiesType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="projectListType">
+        <xs:sequence>
+            <xs:element name="project" type="projectType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="projectType">
+        <xs:sequence>
+            <xs:element name="owner" type="userType" minOccurs="0" />
+        </xs:sequence>
+        <xs:attribute name="id" type="resourceIdType" />
+        <xs:attribute name="name" type="xs:string" />
+        <xs:attribute name="description" type="xs:string" />
+        <xs:attribute name="topLevelProject" type="xs:boolean" />
+        <xs:attribute name="parentProjectId" type="resourceIdType" />
+        <xs:attribute name="createdAt" type="xs:dateTime" />
+        <xs:attribute name="updatedAt" type="xs:dateTime" />
+        <xs:attribute name="contentPermissions">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="LockedToProject" />
+                    <xs:enumeration value="ManagedByOwner" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="scheduleListType">
+        <xs:sequence>
+            <xs:element name="schedule" type="scheduleType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="scheduleType">
+        <xs:sequence>
+            <xs:element name="frequencyDetails" type="frequencyDetailsType" />
+        </xs:sequence>
+        <xs:attribute name="id" type="resourceIdType" />
+        <xs:attribute name="name" type="xs:string" />
+        <xs:attribute name="state" type="stateType" />
+        <xs:attribute name="priority" type="xs:nonNegativeInteger" />
+        <xs:attribute name="createdAt" type="xs:dateTime" />
+        <xs:attribute name="updatedAt" type="xs:dateTime" />
+        <xs:attribute name="type" >
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="Extract" />
+                    <xs:enumeration value="Subscription" />
+                    <xs:enumeration value="ActiveDirectorySync" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="frequency">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="Hourly" />
+                    <xs:enumeration value="Daily" />
+                    <xs:enumeration value="Weekly" />
+                    <xs:enumeration value="Monthly" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="nextRunAt" type="xs:dateTime" />
+        <xs:attribute name="endScheduleAt" type="xs:dateTime" />
+        <xs:attribute name="executionOrder" >
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="Parallel" />
+                    <xs:enumeration value="Serial" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="siteListType">
+        <xs:sequence>
+            <xs:element name="site" type="siteType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="siteType">
+        <xs:sequence>
+            <xs:element name="usage" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="numUsers" type="xs:nonNegativeInteger" use="required" />
+                    <xs:attribute name="numCreators" type="xs:nonNegativeInteger" />
+                    <xs:attribute name="numExplorers" type="xs:nonNegativeInteger" />
+                    <xs:attribute name="numViewers" type = "xs:nonNegativeInteger" />
+                    <xs:attribute name="storage" type="xs:nonNegativeInteger" use="required" />
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="id" type="resourceIdType" />
+        <xs:attribute name="name" type="xs:string" />
+        <xs:attribute name="contentUrl" type="xs:string" /> <!-- consider restricting to a rex for valid URLs -->
+        <xs:attribute name="adminMode">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="ContentOnly" />
+                    <xs:enumeration value="ContentAndUsers" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="userQuota" type="siteQuotaType" />
+        <xs:attribute name="storageQuota" type="siteQuotaType" />
+        <xs:attribute name="tierCreatorCapacity" type="siteCapacityType" />
+        <xs:attribute name="tierExplorerCapacity" type="siteCapacityType" />
+        <xs:attribute name="tierViewerCapacity" type="siteCapacityType" />
+        <xs:attribute name="disableSubscriptions" type="xs:boolean" />
+        <xs:attribute name="state" type="stateType" />
+        <xs:attribute name="revisionHistoryEnabled" type="xs:boolean" />
+        <xs:attribute name="revisionLimit" type="revisionLimitType" />
+        <xs:attribute name="subscribeOthersEnabled" type="xs:boolean" />
+        <xs:attribute name="guestAccessEnabled" type="xs:boolean" />
+        <xs:attribute name="cacheWarmupEnabled" type="xs:boolean" />
+        <xs:attribute name="commentingEnabled" type="xs:boolean" />
+        <xs:attribute name="cacheeWarmupThreshold" type="xs:nonNegativeInteger" />
+    </xs:complexType>
+
+    <!-- Credentials for accessing Tableau Server -->
+    <xs:complexType name="tableauCredentialsType">
+        <xs:sequence>
+            <xs:element name="site" type="siteType" minOccurs="1" maxOccurs="1" />
+            <xs:element name="user" type="userType" minOccurs="0" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" />
+        <xs:attribute name="password" type="xs:string" />
+        <xs:attribute name="token" type="xs:string" />
+    </xs:complexType>
+
+    <xs:complexType name="tagListType">
+        <xs:sequence>
+            <xs:element name="tag" type="tagType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="tagType">
+        <xs:attribute name="label" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="userListType">
+        <xs:sequence>
+            <xs:element name="user" type="userType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="userType">
+        <xs:sequence>
+            <xs:element name="domain" type="domainDirectiveType" minOccurs="0" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="id" type="resourceIdType" />
+        <xs:attribute name="name" type="xs:string" />
+        <xs:attribute name="fullName" type="xs:string" />
+        <xs:attribute name="email" type="xs:string" />
+        <xs:attribute name="password" type="xs:string" />
+        <xs:attribute name="siteRole" type="siteRoleType" />
+        <xs:attribute name="authSetting" type="siteUserAuthSettingType" />
+        <xs:attribute name="lastLogin" type="xs:dateTime" />
+        <xs:attribute name="externalAuthUserId" type="xs:string" />
+    </xs:complexType>
+
+    <xs:complexType name="viewListType">
+        <xs:sequence>
+            <xs:element name="view" type="viewType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="viewType">
+        <xs:sequence>
+            <xs:element name="workbook" type="workbookType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="owner" type="userType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="project" type="projectType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="tags" type="tagListType" minOccurs="0" />
+            <xs:element name="usage" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="totalViewCount" type="xs:nonNegativeInteger" use="required" />
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="id" type="resourceIdType" />
+        <xs:attribute name="name" type="xs:string" />
+        <xs:attribute name="contentUrl" type="xs:string" />
+        <xs:attribute name="createdAt" type="xs:dateTime" />
+        <xs:attribute name="updatedAt" type="xs:dateTime" />
+        <xs:attribute name="sheetType" type="xs:string" />
+    </xs:complexType>
+
+    <xs:complexType name="workbookListType">
+        <xs:sequence>
+            <xs:element name="workbook" type="workbookType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="workbookType">
+        <xs:sequence>
+            <xs:element name="connections" type="connectionListType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="connectionCredentials" type="connectionCredentialsType" minOccurs="0" />
+            <xs:element name="site" type="siteType" minOccurs="0" />
+            <xs:element name="project" type="projectType" minOccurs="0" />
+            <xs:element name="owner" type="userType" minOccurs="0" />
+            <xs:element name="tags" type="tagListType" minOccurs="0" />
+            <xs:element name="views" type="viewListType" minOccurs="0" />
+        </xs:sequence>
+        <xs:attribute name="id" type="resourceIdType" />
+        <xs:attribute name="name" type="xs:string" />
+        <xs:attribute name="description" type="xs:string" />
+        <xs:attribute name="contentUrl" type="xs:string" />
+        <xs:attribute name="showTabs" type="xs:boolean" />
+        <xs:attribute name="size" type="xs:nonNegativeInteger" />
+        <xs:attribute name="createdAt" type="xs:dateTime" />
+        <xs:attribute name="updatedAt" type="xs:dateTime" />
+    </xs:complexType>
+
+    <!--
+        Definition of supporting types for message payloads
+    -->
+
+    <xs:complexType name="capabilityType">
+        <xs:attribute name="name" use="required" >
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="AddComment" />
+                    <xs:enumeration value="ChangeHierarchy" />
+                    <xs:enumeration value="ChangePermissions" />
+                    <xs:enumeration value="Connect" />
+                    <xs:enumeration value="Delete" />
+                    <xs:enumeration value="ExportData" />
+                    <xs:enumeration value="ExportImage" />
+                    <xs:enumeration value="ExportXml" />
+                    <xs:enumeration value="Filter" />
+                    <xs:enumeration value="ProjectLeader" />
+                    <xs:enumeration value="Read" />
+                    <xs:enumeration value="ShareView" />
+                    <xs:enumeration value="ViewComments" />
+                    <xs:enumeration value="ViewUnderlyingData" />
+                    <xs:enumeration value="WebAuthoring" />
+                    <xs:enumeration value="Write" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="mode" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="Allow" />
+                    <xs:enumeration value="Deny" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="fileUploadSessionIdType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="([0-9]+:[0-9a-fA-F]+)-([0-9]+:[0-9]+)"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="domainDirectiveType">
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="importDirectiveType">
+        <xs:attribute name="source" type="importSourceType" use="required" />
+        <xs:attribute name="domainName" type="xs:string" use="required" />
+        <xs:attribute name="siteRole" type="siteRoleType" use="required" />
+    </xs:complexType>
+
+    <xs:simpleType name="importSourceType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ActiveDirectory" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="granteeCapabilitiesType">
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="group" type="groupType" />
+                <xs:element name="user" type="userType" />
+            </xs:choice>
+            <xs:element name="capabilities">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="capability" type="capabilityType" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="paginationType">
+        <xs:attribute name="pageNumber" type="xs:positiveInteger" use="required" />
+        <xs:attribute name="pageSize" type="xs:nonNegativeInteger" use="required" />
+        <xs:attribute name="totalAvailable" type="xs:nonNegativeInteger" use="required" />
+    </xs:complexType>
+
+    <xs:simpleType name="resourceIdType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="siteRoleType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Creator" />
+            <xs:enumeration value="Explorer" />
+            <xs:enumeration value="ExplorerCanPublish" />
+            <xs:enumeration value="Guest" />
+            <xs:enumeration value="Interactor" />
+            <xs:enumeration value="Publisher" />
+            <xs:enumeration value="ReadOnly" />
+            <xs:enumeration value="ServerAdministrator" />
+            <xs:enumeration value="SiteAdministrator" />
+            <xs:enumeration value="SiteAdministratorCreator" />
+            <xs:enumeration value="SiteAdministratorExplorer" />
+            <xs:enumeration value="Unlicensed" />
+            <xs:enumeration value="UnlicensedWithPublish" />
+            <xs:enumeration value="Viewer" />
+            <xs:enumeration value="ViewerWithPublish" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="siteUserAuthSettingType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ServerDefault" />
+            <xs:enumeration value="SAML" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="stateType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Active" />
+            <xs:enumeration value="Suspended" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="statusNoteListType">
+        <xs:sequence>
+            <xs:element name="statusNote" type="statusNoteType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="statusNoteType">
+        <xs:attribute name="type" use="required" >
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="CountOfUsersAddedToGroup" />
+                    <xs:enumeration value="CountOfUsersAddedToSite" />
+                    <xs:enumeration value="CountOfUsersWithInsufficientLicenses" />
+                    <xs:enumeration value="CountOfUsersInActiveDirectoryGroup" />
+                    <xs:enumeration value="CountOfUsersProcessed" />
+                    <xs:enumeration value="CountOfUsersSkipped" />
+                    <xs:enumeration value="CountOfUsersInformationUpdated" />
+                    <xs:enumeration value="CountOfUsersSiteRoleUpdated" />
+                    <xs:enumeration value="CountOfUsersRemovedFromGroup" />
+                    <xs:enumeration value="CountOfUsersUnlicensed" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="value" type="xs:string" />
+        <xs:attribute name="text" type="xs:string" />
+    </xs:complexType>
+
+    <xs:simpleType name="siteQuotaType">
+        <xs:restriction base="xs:integer">
+            <xs:minInclusive value="-1"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="siteCapacityType">
+        <xs:restriction base="xs:integer">
+            <xs:minInclusive value="0"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="revisionLimitType">
+        <xs:union>
+            <xs:simpleType>
+                <xs:annotation>
+                    <xs:documentation>Not a real value. Used to specify 'no limit' when site is created or updated. Never returned from server in response.</xs:documentation>
+                </xs:annotation>
+                <xs:restriction base="xs:integer">
+                    <xs:enumeration value="-1"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:integer">
+                    <xs:minInclusive value="2"/>
+                    <xs:maxInclusive value="10000"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:union>
+    </xs:simpleType>
+
+    <xs:complexType name="parentType">
+      <xs:attribute name="id" type="resourceIdType" use="required" />
+      <xs:attribute name="type" use="required" >
+          <xs:simpleType>
+              <xs:restriction base="xs:string">
+                  <xs:enumeration value="Project" />
+              </xs:restriction>
+          </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="name" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="frequencyDetailsType">
+        <xs:sequence>
+            <xs:element name="intervals" minOccurs="1" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="interval" type="intervalType" minOccurs="1" maxOccurs="7" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="start" type="xs:time" use="required" />
+        <xs:attribute name="end" type="xs:time" />
+    </xs:complexType>
+
+    <xs:complexType name="intervalType">
+        <xs:attribute name="minutes">
+            <xs:simpleType>
+                <xs:restriction base="xs:nonNegativeInteger">
+                    <xs:enumeration value="15" />
+                    <xs:enumeration value="30" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="hours">
+            <xs:simpleType>
+                <xs:restriction base="xs:nonNegativeInteger">
+                    <xs:enumeration value="1" />
+                    <xs:enumeration value="2" />
+                    <xs:enumeration value="4" />
+                    <xs:enumeration value="6" />
+                    <xs:enumeration value="8" />
+                    <xs:enumeration value="12" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="weekDay" >
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="Monday" />
+                    <xs:enumeration value="Tuesday" />
+                    <xs:enumeration value="Wednesday" />
+                    <xs:enumeration value="Thursday" />
+                    <xs:enumeration value="Friday" />
+                    <xs:enumeration value="Saturday" />
+                    <xs:enumeration value="Sunday" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="monthDay" >
+            <xs:simpleType>
+                <xs:union>
+                    <xs:simpleType>
+                        <xs:restriction base="xs:integer">
+                            <xs:minInclusive value="1" />
+                            <xs:maxInclusive value="31" />
+                        </xs:restriction>
+                    </xs:simpleType>
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:enumeration value="LastDay" />
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:union>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!-- Subscription -->
+    <xs:complexType name="subscriptionListType">
+        <xs:sequence>
+            <xs:element name="subscription" type="subscriptionType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="subscriptionType">
+        <xs:sequence>
+            <xs:element name="content" type="subscriptionContentType" />
+            <xs:element name="schedule" type="scheduleType" />
+            <xs:element name="user" type="userType" />
+        </xs:sequence>
+        <xs:attribute name="id" type="resourceIdType" />
+        <xs:attribute name="subject" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="subscriptionContentType">
+      <xs:attribute name="id" type="resourceIdType" use="required" />
+      <xs:attribute name="type" use="required" >
+          <xs:simpleType>
+              <xs:restriction base="xs:string">
+                  <xs:enumeration value="Workbook" />
+                  <xs:enumeration value="View" />
+              </xs:restriction>
+          </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="name" use="optional" />
+    </xs:complexType>
+
+    <!-- ServerInfo -->
+    <xs:complexType name="serverInfo">
+        <xs:sequence>
+            <xs:element name="productVersion" type="productVersion"/>
+            <xs:element name="restApiVersion" type="restApiVersion"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="productVersion">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="build" >
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:pattern value="[0-9]{5}.[0-9]{2}.[0-9]{4}.[0-9]{4}" />
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:simpleType name="restApiVersion">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{5}.[0-9]{2}.[0-9]{4}.[0-9]{4}" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- Tasks -->
+    <xs:complexType name="taskListType">
+        <xs:sequence>
+            <xs:element name="task" type="taskType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="taskType">
+        <xs:choice>
+            <xs:element name="extractRefresh" type="taskExtractRefreshType" />
+        </xs:choice>
+        <xs:attribute name="runNow" type="xs:boolean" />
+
+    </xs:complexType>
+
+    <xs:complexType name="taskExtractRefreshType">
+        <xs:sequence>
+            <xs:element name="schedule" type="scheduleType" minOccurs="0" maxOccurs="1" />
+            <xs:choice>
+                <xs:element name="view" type="viewType" />
+                <xs:element name="workbook" type="workbookType" />
+                <xs:element name="datasource" type="dataSourceType" />
+            </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="id" type="xs:string"/>
+        <xs:attribute name="priority" type="xs:nonNegativeInteger"/>
+        <xs:attribute name="consecutiveFailedCount" type="xs:nonNegativeInteger"/>
+        <xs:attribute name="type" type="xs:string" />
+        <xs:attribute name="incremental" type="xs:boolean" />
+    </xs:complexType>
+</xs:schema>

--- a/java/src/com/tableausoftware/documentation/api/rest/Demo.java
+++ b/java/src/com/tableausoftware/documentation/api/rest/Demo.java
@@ -9,8 +9,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.log4j.BasicConfigurator;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import com.tableausoftware.documentation.api.rest.bindings.GranteeCapabilitiesType;
 import com.tableausoftware.documentation.api.rest.bindings.GroupType;
@@ -38,15 +38,16 @@ import com.tableausoftware.documentation.api.rest.util.RestApiUtils;
  */
 public class Demo {
 
-    private static Logger s_logger = Logger.getLogger(Demo.class);
+    private static Logger s_logger = LogManager.getLogger();
 
     private static Properties s_properties = new Properties();
 
     private static final RestApiUtils s_restApiUtils = RestApiUtils.getInstance();
 
     static {
-        // Configures the logger to log to stdout
-        BasicConfigurator.configure();
+        org.apache.logging.log4j.core.config.Configurator.setAllLevels(
+                LogManager.getRootLogger().getName(), org.apache.logging.log4j.Level.ALL);
+        s_logger.info("Configuring...");
 
         // Loads the values from configuration file into the Properties instance
         try {
@@ -57,6 +58,7 @@ public class Demo {
     }
 
     public static void main(String[] args) {
+        s_logger.info("Running...");
         // Sets the username, password, and content URL, which are all required
         // in the payload of a Sign In request
         String username = s_properties.getProperty("user.admin.name");
@@ -65,6 +67,11 @@ public class Demo {
 
         // Signs in to server and saves the authentication token, site ID, and current user ID
         TableauCredentialsType credential = s_restApiUtils.invokeSignIn(username, password, contentUrl);
+
+        if (credential == null || credential.getSite() == null || credential.getToken() == null){
+            s_logger.error("Failed to sign in: null or invalid credential returned");
+            return;
+        }
         String currentSiteId = credential.getSite().getId();
         String currentUserId = credential.getUser().getId();
 

--- a/java/src/com/tableausoftware/documentation/api/rest/util/RestApiUtils.java
+++ b/java/src/com/tableausoftware/documentation/api/rest/util/RestApiUtils.java
@@ -22,7 +22,8 @@ import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.xml.sax.SAXException;
 
 import com.google.common.io.Files;
@@ -110,32 +111,49 @@ public class RestApiUtils {
      * @return the URI builder
      */
     private static UriBuilder getApiUriBuilder() {
-        return UriBuilder.fromPath(m_properties.getProperty("server.host") + "/api/3.1");
+        return UriBuilder.fromPath(m_properties.getProperty("server.host")
+                        + "/api/"
+                        + m_properties.getProperty("server.schema.version"));
     }
     /**
      * Initializes the RestApiUtils. The initialize code loads values from the configuration
      * file and initializes the JAXB marshaller and unmarshaller.
      */
     private static void initialize() {
+        m_logger.info("Initializing...");
         try {
             m_properties.load(new FileInputStream("res/config.properties"));
-            JAXBContext jaxbContext = JAXBContext.newInstance(TsRequest.class, TsResponse.class);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to read configuration properties");
+        }
+        Schema schema;
+        try {
+            final String schemaLocation = m_properties.getProperty("server.schema.location");
+            m_logger.info("Schema at " + schemaLocation);
+            File schemaFile = new File(schemaLocation);
             SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-            Schema schema = schemaFactory.newSchema(new File(m_properties.getProperty("server.schema.location")));
+            schema = schemaFactory.newSchema(schemaFile);
+            m_logger.info("Schema factory complete");
+        } catch (SAXException ex) {
+            throw new IllegalStateException("Failed to load schema file");
+        }
+        try {
+            JAXBContext jaxbContext = JAXBContext.newInstance(TsRequest.class, TsResponse.class);
             s_jaxbMarshaller = jaxbContext.createMarshaller();
             s_jaxbUnmarshaller = jaxbContext.createUnmarshaller();
             s_jaxbUnmarshaller.setSchema(schema);
             s_jaxbMarshaller.setSchema(schema);
-        } catch (JAXBException | SAXException | IOException ex) {
-            throw new IllegalStateException("Failed to initialize the REST API");
+        } catch (JAXBException ex) {
+            throw new IllegalStateException("Failed to initialize the REST API with schema", ex);
         }
+        m_logger.info("Schema initialization complete");
     }
 
     private final String TABLEAU_AUTH_HEADER = "X-Tableau-Auth";
 
     private final String TABLEAU_PAYLOAD_NAME = "request_payload";
 
-    private Logger m_logger = Logger.getLogger(RestApiUtils.class);
+    private static Logger m_logger = LogManager.getLogger();
 
     private ObjectFactory m_objectFactory = new ObjectFactory();
 
@@ -398,7 +416,7 @@ public class RestApiUtils {
         TsResponse response = post(url, null, payload);
 
         // Verifies that the response has a credentials element
-        if (response.getCredentials() != null) {
+        if (response != null && response.getCredentials() != null) {
             m_logger.info("Sign in is successful!");
 
             return response.getCredentials();
@@ -795,21 +813,23 @@ public class RestApiUtils {
      * @return the response from the request
      */
     private TsResponse post(String url, String authToken, TsRequest requestPayload) {
-        // Creates an instance of StringWriter to hold the XML for the request
-        StringWriter writer = new StringWriter();
+        String payload = "";
 
         // Marshals the TsRequest object into XML format if it is not null
         if (requestPayload != null) {
+            // Creates an instance of StringWriter to hold the XML for the request
+            StringWriter writer = new StringWriter();
+
             try {
                 s_jaxbMarshaller.marshal(requestPayload, writer);
             } catch (JAXBException ex) {
-                m_logger.error("There was a problem marshalling the payload");
+                m_logger.error("There was a problem marshalling the payload: " + ex);
+                m_logger.error("Not posting to " + url);
+                throw new IllegalStateException(ex);
             }
+            // Converts the XML into a string
+            payload = writer.toString();
         }
-
-        // Converts the XML into a string
-        String payload = writer.toString();
-
         m_logger.debug("Input payload: \n" + payload);
 
         // Creates the HTTP client object and makes the HTTP request to the
@@ -1018,8 +1038,10 @@ public class RestApiUtils {
             StringReader reader = new StringReader(responseXML);
             tsResponse = s_jaxbUnmarshaller.unmarshal(new StreamSource(reader), TsResponse.class).getValue();
         } catch (JAXBException e) {
-            m_logger.error("Failed to parse response from server due to:");
-            e.printStackTrace();
+            m_logger.error("Failed to parse response from server due to:" + e.toString());
+            // if more information is needed
+            // e.printStackTrace();
+            m_logger.error(responseXML);
         }
 
         return tsResponse;


### PR DESCRIPTION
- update log4j to log4j2
- java11 requires jakarta since jaxb is no longer in the std lib
- Also added some debug statements and separated out possible exceptions for easier debugging.
- Updated the code to refer to config.properties instead of requiring the user to edit code before running.
- Set a default API version so that the user doesn't have to find and download a schema before first run