### PR TITLE
🐛 fixing RequestField and encode_multipart_formdata imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 
 # python files
 *.pyc
+
+/.idea

--- a/python/publish_workbook.py
+++ b/python/publish_workbook.py
@@ -36,8 +36,8 @@ import getpass
 
 # The following packages are used to build a multi-part/mixed request.
 # They are contained in the 'requests' library
-from requests.packages.urllib3.fields import RequestField
-from requests.packages.urllib3.filepost import encode_multipart_formdata
+from urllib3.fields import RequestField
+from urllib3.filepost import encode_multipart_formdata
 
 # The namespace for the REST API is 'http://tableausoftware.com/api' for Tableau Server 9.0
 # or 'http://tableau.com/api' for Tableau Server 9.1 or later


### PR DESCRIPTION
Historically, requests "vendorized" urllib3 (and others), and you could import RequestField and encode_multipart_formdata via requests.packages.urllib3.... 

In recent versions, requests no longer includes urllib3 "inside" itself; it depends on urllib3 installed in the environment. 

The requests.packages module is now just a shim, and the type stubs (packages.pyi) don't expose urllib3