### PR TITLE
Bump log4j to 2.26.1 and remove legacy log4j 1.x dependency

### DIFF
--- a/java/ivy.xml
+++ b/java/ivy.xml
@@ -1,13 +1,10 @@
 <ivy-module version="2.0">
     <info organisation="org.tableau" module="tab-documentation-api"/>
     <dependencies>
-        <dependency org="org.apache.logging.log4j" name="log4j-api" rev="2.12.1" />
-        <dependency org="org.apache.logging.log4j" name="log4j-core" rev="2.12.1" />
+        <dependency org="org.apache.logging.log4j" name="log4j-api" rev="2.26.1" />
+        <dependency org="org.apache.logging.log4j" name="log4j-core" rev="2.26.1" />
         <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
         <dependency org="com.google.guava" name="guava" rev="16.0.1"/>
-        <!-- https://mvnrepository.com/artifact/log4j/log4j -->
-        <dependency org="org.apache.logging.log4j" name="log4j-api" rev="2.19.0" />
-        <dependency org="org.apache.logging.log4j" name="log4j-core" rev="2.19.0" />
         <!-- https://mvnrepository.com/artifact/com.sun.jersey/jersey-client -->
         <dependency org="com.sun.jersey" name="jersey-client" rev="1.18.3"/>
         <!-- https://mvnrepository.com/artifact/com.sun.jersey/jersey-core -->


### PR DESCRIPTION
## Summary
- Bumps `log4j-api` and `log4j-core` from 2.12.1 to 2.26.1 in `java/ivy.xml`
- Removes the duplicate legacy `log4j` 1.x dependency entry